### PR TITLE
Add RSI and MACD studies to SPY TradingView chart

### DIFF
--- a/spy_dashboard_app.jsx
+++ b/spy_dashboard_app.jsx
@@ -16,7 +16,8 @@ export default function Home() {
       toolbar_bg: "#f1f3f6",
       enable_publishing: false,
       allow_symbol_change: true,
-      container_id: "tradingview_spy_chart"
+      container_id: "tradingview_spy_chart",
+      studies: ["RSI@tv-basicstudies", "MACD@tv-basicstudies"],
     });
     document.getElementById("tradingview_spy_chart")?.appendChild(script);
   }, []);


### PR DESCRIPTION
## Summary
- add RSI and MACD studies to embedded SPY TradingView chart

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e704b28a08331919048c1f2bc792b